### PR TITLE
Implemented metrics related with MATCH_REGEX_COUNT

### DIFF
--- a/ingestion/src/metadata/orm_profiler/metrics/registry.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/registry.py
@@ -70,6 +70,8 @@ class Metrics(MetricRegistry):
     MAX_LENGTH = MaxLength
     MIN = Min
     MIN_LENGTH = MinLength
+    MATCH_REGEX_COUNT = MatchRegexCount
+    NOT_MATCH_REGEX_COUNT = NotMatchRegexCount
     NULL_COUNT = NullCount
     ROW_COUNT = RowCount
     STDDEV = StdDev

--- a/ingestion/src/metadata/orm_profiler/metrics/static/match_regex_count.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/match_regex_count.py
@@ -1,0 +1,42 @@
+"""
+Match Regex Metric definition
+"""
+# pylint: disable=duplicate-code
+
+from sqlalchemy import case, column
+
+from metadata.orm_profiler.metrics.core import StaticMetric, _label
+from metadata.orm_profiler.orm.functions.sum import SumFn
+from metadata.orm_profiler.orm.functions.regex_match import MatchRegexFn
+
+
+class MatchRegexCount(StaticMetric):
+    """
+    MATCH_REGEX_COUNT Metric
+
+    Given a column, and an expression, return the number of
+    rows that match it
+
+    This Metric needs to be initialised passing the expression to check
+    add_props(expression="j%")(Metrics.MATCH_REGEX_COUNT.value)
+    """
+
+    expression: str
+
+    @classmethod
+    def name(cls):
+        return "matchRegexCount"
+
+    @property
+    def metric_type(self):
+        return int
+
+    @_label
+    def fn(self):
+        if not hasattr(self, "expression"):
+            raise AttributeError(
+                "Not Like Count requires an expression to be set: add_props(expression=...)(Metrics.MATCH_REGEX_COUNT)"
+            )
+        return SumFn(
+            case([(column(self.col.name).MatchRegexFn(self.expression), 1)], else_=0)
+        )

--- a/ingestion/src/metadata/orm_profiler/metrics/static/not_match_regex_count.py
+++ b/ingestion/src/metadata/orm_profiler/metrics/static/not_match_regex_count.py
@@ -1,0 +1,42 @@
+"""
+NOT Match Regex Metric definition
+"""
+# pylint: disable=duplicate-code
+
+from sqlalchemy import case, column
+
+from metadata.orm_profiler.metrics.core import StaticMetric, _label
+from metadata.orm_profiler.orm.functions.sum import SumFn
+from metadata.orm_profiler.orm.functions.regex_match import MatchRegexFn
+
+
+class NotMatchRegexCount(StaticMetric):
+    """
+    NOT_MATCH_REGEX_COUNT Metric
+
+    Given a column, and an expression, return the number of
+    rows that match the forbidden regex pattern
+
+    This Metric needs to be initialised passing the expression to check
+    add_props(expression="j%")(Metrics.NOT_MATCH_REGEX_COUNT.value)
+    """
+
+    expression: str
+
+    @classmethod
+    def name(cls):
+        return "notMatchRegexCount"
+
+    @property
+    def metric_type(self):
+        return int
+
+    @_label
+    def fn(self):
+        if not hasattr(self, "expression"):
+            raise AttributeError(
+                "Not Like Count requires an expression to be set: add_props(expression=...)(Metrics.NOT_MATCH_REGEX_COUNT)"
+            )
+        return SumFn(
+            case([(column(self.col.name).MatchRegexFn(self.expression), 0)], else_=1)
+        )

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_match_regex.py
@@ -52,7 +52,7 @@ def column_values_to_match_regex(
     regex = next(
         (param.value for param in test_case.parameterValues if param.name == "regex")
     )
-    like_count = add_props(expression=regex)(Metrics.LIKE_COUNT.value)
+    like_count = add_props(expression=regex)(Metrics.MATCH_REGEX_COUNT.value)
 
     try:
         column_name = get_decoded_column(test_case.entityLink.__root__)

--- a/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
+++ b/ingestion/src/metadata/test_suite/validations/column/column_values_to_not_match_regex.py
@@ -56,7 +56,7 @@ def column_values_to_not_match_regex(
             if param.name == "forbiddenRegex"
         )
     )
-    not_like_count = add_props(expression=forbidden_regex)(Metrics.NOT_LIKE_COUNT.value)
+    not_like_count = add_props(expression=forbidden_regex)(Metrics.NOT_MATCH_REGEX_COUNT.value)
 
     try:
         column_name = get_decoded_column(test_case.entityLink.__root__)


### PR DESCRIPTION
change the original Like_COUNT related metric in column_values_to_match_regex.py and column_values_to_not_match_regex.py

### Describe your changes :
<!-- Explain what you have done & tag your assigned issue !-->
I worked on the ..... because ...

#
### Type of change :
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [x] Improvement
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### Frontend Preview (Screenshots) :
<p align="center">For frontend related change, please link screenshots of your changes preview! Optional for backend related changes.
</p>

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] All new and existing tests passed.

#
### Reviewers
<!-- Please see the contributing guidelines and then add your reviewer(s) !-->
<!--- OpenMetadata community thanks you for explaining your changes in detail !-->
<!--- If you are unsure of people to review your work, you can add anyone of these developers :) !-->
<!--- Frontend: @open-metadata/ui -->
<!--- Backend: @open-metadata/backend -->
<!--- Ingestion: @open-metadata/ingestion -->
